### PR TITLE
Allow for an empty watchers list

### DIFF
--- a/lib/ecto_watch/watcher_options.ex
+++ b/lib/ecto_watch/watcher_options.ex
@@ -1,10 +1,6 @@
 defmodule EctoWatch.WatcherOptions do
   defstruct [:schema_mod, :update_type, :opts]
 
-  def validate_list([]) do
-    {:error, "requires at least one watcher"}
-  end
-
   def validate_list(list) when is_list(list) do
     result =
       list


### PR DESCRIPTION
For my deploy, I needed to turn off `ecto_watch` in test mode. They had a 100% fail rate, same error as #9 

I like the way Oban handles this, where in the tests you set the Oban config to nothing and it works itself out. Then they have specific test helpers to help you write tests.

I didn't remove the requirement for pubsub or repo, although I think it would be neat if those could only be required if there are any watchers.

So my `test/config.exs` now looks like:

```
config :my_app, EctoWatch,
  repo: MyApp.Repo,
  pubsub: MyApp.PubSub,
  watchers: []
```