### PR TITLE
Fix/deal with truncated trigger names

### DIFF
--- a/lib/ecto_watch/helpers.ex
+++ b/lib/ecto_watch/helpers.ex
@@ -1,22 +1,6 @@
 defmodule EctoWatch.Helpers do
   @moduledoc false
-
   require Logger
-
-  def label(schema_mod_or_label) do
-    if ecto_schema_mod?(schema_mod_or_label) do
-      module_to_label(schema_mod_or_label)
-    else
-      schema_mod_or_label
-    end
-  end
-
-  def module_to_label(module) do
-    module
-    |> Module.split()
-    |> Enum.join("_")
-    |> String.downcase()
-  end
 
   def ecto_schema_mod?(schema_mod) do
     schema_mod.__schema__(:fields)

--- a/lib/ecto_watch/inspector.ex
+++ b/lib/ecto_watch/inspector.ex
@@ -1,0 +1,107 @@
+defmodule EctoWatch.Inspector do
+  @moduledoc """
+  Use this module to compare given configuration VS triggers / functions in the DB
+  """
+
+  alias EctoWatch.WatcherTriggerValidator.FunctionDetails
+  alias EctoWatch.WatcherTriggerValidator.TriggerDetails
+
+  def watcher_details do
+    case EctoWatch.WatcherSupervisor.watcher_details() do
+      {:ok, watcher_details} ->
+        watcher_details
+
+      {:error, message} ->
+        raise message
+    end
+  end
+
+  def repo_details(repo_mod) do
+    by_repo = Enum.group_by(watcher_details(), & &1.repo_mod)
+    details = Map.get(by_repo, repo_mod)
+    summary_for_repo(repo_mod, details)
+  end
+
+  defp triggers_for_repo(details) do
+    details
+    |> Enum.map(fn details ->
+      %TriggerDetails{
+        name: details.trigger_name,
+        table_schema: details.schema_definition.schema_prefix,
+        table_name: details.schema_definition.table_name
+      }
+    end)
+    |> MapSet.new()
+  end
+
+  defp functions_for_repo(details) do
+    details
+    |> Enum.map(fn details ->
+      %FunctionDetails{
+        name: details.function_name,
+        schema: details.schema_definition.schema_prefix
+      }
+    end)
+    |> MapSet.new()
+  end
+
+  defp summary_for_repo(repo_mod, details) do
+    specified_triggers = triggers_for_repo(details)
+    specified_functions = functions_for_repo(details)
+    found_triggers = find_triggers(repo_mod)
+    found_functions = find_functions(repo_mod)
+
+    Map.new([
+      {
+        repo_mod,
+        %{
+          diff_triggers: MapSet.difference(found_triggers, specified_triggers),
+          diff_functions: MapSet.difference(found_functions, specified_functions),
+          specified_triggers: specified_triggers,
+          specified_functions: specified_functions,
+          found_triggers: found_triggers,
+          found_functions: found_functions
+        }
+      }
+    ])
+  end
+
+  defp find_triggers(repo_mod) do
+    sql_query(
+      repo_mod,
+      """
+      SELECT trigger_name, event_object_schema, event_object_table
+      FROM information_schema.triggers
+      WHERE trigger_name LIKE 'ew_%'
+      """
+    )
+    |> Enum.map(fn [name, table_schema, table_name] ->
+      %TriggerDetails{
+        name: name,
+        table_schema: table_schema,
+        table_name: table_name
+      }
+    end)
+    |> MapSet.new()
+  end
+
+  defp find_functions(repo_mod) do
+    sql_query(
+      repo_mod,
+      """
+      SELECT n.nspname AS schema, p.proname AS name
+      FROM pg_proc p LEFT JOIN pg_namespace n ON p.pronamespace = n.oid
+      WHERE n.nspname NOT IN ('pg_catalog', 'information_schema') AND p.proname LIKE 'ew_%'
+      ORDER BY schema, name;
+      """
+    )
+    |> Enum.map(fn [schema, name] -> %FunctionDetails{name: name, schema: schema} end)
+    |> MapSet.new()
+  end
+
+  defp sql_query(repo_mod, query) do
+    %Postgrex.Result{rows: rows} = Ecto.Adapters.SQL.query!(repo_mod, query, [])
+
+    rows
+  end
+end

--- a/lib/ecto_watch/label.ex
+++ b/lib/ecto_watch/label.ex
@@ -1,0 +1,73 @@
+defmodule EctoWatch.Label do
+  alias EctoWatch.Helpers
+  alias EctoWatch.Options.WatcherOptions
+
+  @doc """
+  To make things simple: generate a single string which is unique for each watcher
+  that can be used as the watcher process name, trigger name, trigger function name,
+  and Phoenix.PubSub channel name.
+  """
+  def unique_label(%WatcherOptions{} = options) do
+    options
+    |> identifier()
+    |> unique_label()
+  end
+
+  def unique_label({schema_mod, update_type}) do
+    update_type = short_update_type(update_type)
+    :"ew_#{update_type}_for_#{truncated_label(schema_mod)}"
+  end
+
+  def unique_label(label) do
+    :"ew_for_#{truncated_label(label)}"
+  end
+
+  def identifier(%WatcherOptions{} = options) do
+    if options.label do
+      options.label
+    else
+      {options.schema_definition.label, options.update_type}
+    end
+  end
+
+  defp short_update_type(update_type) do
+    case update_type do
+      :inserted -> "i"
+      :updated -> "u"
+      :deleted -> "d"
+    end
+  end
+
+  defp truncated_label(label) do
+    label = label(label)
+    string_label = to_string(label)
+    chsum = :erlang.phash2(string_label) |> to_string()
+    length = String.length(string_label)
+
+    if length > 63 - 9 do
+      # 63 = max length of a postgres identifier
+      # 9  = ew_for_ + update_type + underscores
+      # 5  = _func / _trig
+      max_length = 63 - 9 - String.length(chsum) - 5
+      sublabel = String.slice(string_label, 0, max_length)
+      "#{sublabel}_#{chsum}"
+    else
+      string_label
+    end
+  end
+
+  defp label(schema_mod_or_label) do
+    if Helpers.ecto_schema_mod?(schema_mod_or_label) do
+      module_to_label(schema_mod_or_label)
+    else
+      schema_mod_or_label
+    end
+  end
+
+  defp module_to_label(module) do
+    module
+    |> Module.split()
+    |> Enum.join("_")
+    |> String.downcase()
+  end
+end

--- a/lib/ecto_watch/label.ex
+++ b/lib/ecto_watch/label.ex
@@ -1,4 +1,5 @@
 defmodule EctoWatch.Label do
+  @moduledoc false
   alias EctoWatch.Helpers
   alias EctoWatch.Options.WatcherOptions
 
@@ -35,6 +36,7 @@ defmodule EctoWatch.Label do
       :inserted -> "i"
       :updated -> "u"
       :deleted -> "d"
+      _ -> raise "unknown update_type: #{update_type}!"
     end
   end
 
@@ -44,11 +46,11 @@ defmodule EctoWatch.Label do
     chsum = :erlang.phash2(string_label) |> to_string()
     length = String.length(string_label)
 
-    if length > 63 - 9 do
-      # 63 = max length of a postgres identifier
-      # 9  = ew_for_ + update_type + underscores
-      # 5  = _func / _trig
-      max_length = 63 - 9 - String.length(chsum) - 5
+    # 63 = max length of a postgres identifier
+    # 10  = ew_for_ + update_type + underscores
+    # 5  = _func / _trig
+    if length > 63 - 10 - 5 do
+      max_length = 63 - 10 - 5 - String.length(chsum)
       sublabel = String.slice(string_label, 0, max_length)
       "#{sublabel}_#{chsum}"
     else

--- a/lib/ecto_watch/watcher_server.ex
+++ b/lib/ecto_watch/watcher_server.ex
@@ -234,7 +234,7 @@ defmodule EctoWatch.WatcherServer do
       schema_definition: options.schema_definition,
       function_name: "#{unique_label}_func",
       notify_channel: unique_label,
-      trigger_name: "#{unique_label}_trigger"
+      trigger_name: "#{unique_label}_trig"
     }
   end
 
@@ -252,34 +252,13 @@ defmodule EctoWatch.WatcherServer do
     unique_label(watcher_options)
   end
 
-  # To make things simple: generate a single string which is unique for each watcher
-  # that can be used as the watcher process name, trigger name, trigger function name,
-  # and Phoenix.PubSub channel name.
-  defp unique_label(%WatcherOptions{} = options) do
-    options
-    |> identifier()
-    |> unique_label()
-  end
-
-  defp unique_label({schema_mod, update_type}) do
-    :"ew_#{update_type}_for_#{Helpers.label(schema_mod)}"
-  end
-
-  defp unique_label(label) do
-    :"ew_for_#{Helpers.label(label)}"
-  end
-
-  defp identifier(%WatcherOptions{} = options) do
-    if options.label do
-      options.label
-    else
-      {options.schema_definition.label, options.update_type}
-    end
+  defp unique_label(anything) do
+    EctoWatch.Label.unique_label(anything)
   end
 
   defp debug_log(%{debug?: debug_value} = options, message) do
     if debug_value do
-      Helpers.debug_log(identifier(options), message)
+      Helpers.debug_log(EctoWatch.Label.identifier(options), message)
     end
   end
 end

--- a/test/ecto_watch_labels_test.exs
+++ b/test/ecto_watch_labels_test.exs
@@ -1,0 +1,218 @@
+defmodule EctoWatchTest do
+  alias EctoWatch.TestRepo
+  use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
+
+  defmodule SuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLong do
+    use Ecto.Schema
+
+    schema "super_long" do
+      field(:the_string, :string)
+      timestamps()
+    end
+  end
+
+  setup do
+    start_supervised!(TestRepo)
+    start_supervised!({Phoenix.PubSub, name: TestPubSub})
+    Ecto.Adapters.SQL.query!(TestRepo, "DROP SCHEMA IF EXISTS \"public\" CASCADE")
+    Ecto.Adapters.SQL.query!(TestRepo, "CREATE SCHEMA \"public\"")
+
+    Ecto.Adapters.SQL.query!(
+      TestRepo,
+      """
+        CREATE TABLE super_long (
+          id SERIAL PRIMARY KEY,
+          the_string TEXT,
+          inserted_at TIMESTAMP,
+          updated_at TIMESTAMP
+        )
+      """,
+      []
+    )
+
+    %Postgrex.Result{
+      rows: [[already_existing_id1]]
+    } =
+      Ecto.Adapters.SQL.query!(
+        TestRepo,
+        """
+        INSERT INTO super_long (the_string, inserted_at, updated_at) VALUES ('super_long', NOW(), NOW())
+        RETURNING id
+        """,
+        []
+      )
+
+    [
+      already_existing_id1: already_existing_id1
+    ]
+  end
+
+  describe "trigger cleanup" do
+    setup do
+      Ecto.Adapters.SQL.query!(
+        TestRepo,
+        """
+        CREATE OR REPLACE FUNCTION \"public\".ew_some_weird_func()
+          RETURNS trigger AS $trigger$
+          BEGIN
+            RETURN NEW;
+          END;
+          $trigger$ LANGUAGE plpgsql;
+        """,
+        []
+      )
+
+      Ecto.Adapters.SQL.query!(
+        TestRepo,
+        """
+        CREATE TRIGGER ew_some_weird_trigger
+          AFTER UPDATE ON \"public\".\"super_long\" FOR EACH ROW
+          EXECUTE PROCEDURE \"public\".ew_some_weird_func();
+        """,
+        []
+      )
+
+      Ecto.Adapters.SQL.query!(
+        TestRepo,
+        """
+        CREATE OR REPLACE FUNCTION \"public\".non_ecto_watch_func()
+          RETURNS trigger AS $trigger$
+          BEGIN
+            RETURN NEW;
+          END;
+          $trigger$ LANGUAGE plpgsql;
+        """,
+        []
+      )
+
+      Ecto.Adapters.SQL.query!(
+        TestRepo,
+        """
+        CREATE TRIGGER non_ecto_watch_trigger
+          AFTER UPDATE ON \"public\".\"super_long\" FOR EACH ROW
+          EXECUTE PROCEDURE \"public\".non_ecto_watch_func();
+        """,
+        []
+      )
+
+      :ok
+    end
+
+    test "warns about extra triggers" do
+      log =
+        capture_log(fn ->
+          start_supervised!(
+            {EctoWatch,
+             repo: TestRepo,
+             pub_sub: TestPubSub,
+             watchers: [
+               {SuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLong,
+                :inserted, label: :trigger_test}
+             ]}
+          )
+
+          Process.sleep(2_000)
+        end)
+
+      IO.inspect(log, label: :log)
+
+      assert log =~
+               ~r/Found the following extra EctoWatch triggers:\n\n"ew_some_weird_trigger" in the table "public"\."super_long"\n\n\.\.\.but they were not specified in the watcher options/
+
+      assert log =~
+               ~r/Found the following extra EctoWatch functions:\n\n"ew_some_weird_func" in the schema "public"/
+
+      refute log =~ ~r/non_ecto_watch_trigger/
+      refute log =~ ~r/non_ecto_watch_func/
+    end
+
+    test "actual cleanup" do
+      System.put_env("ECTO_WATCH_CLEANUP", "cleanup")
+
+      start_supervised!(
+        {EctoWatch,
+         repo: TestRepo,
+         pub_sub: TestPubSub,
+         watchers: [
+           {SuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLong, :inserted,
+            label: :trigger_test}
+         ]}
+      )
+
+      Process.sleep(1_000)
+
+      System.delete_env("ECTO_WATCH_CLEANUP")
+
+      %Postgrex.Result{rows: rows} =
+        Ecto.Adapters.SQL.query!(
+          TestRepo,
+          """
+          SELECT trigger_name
+          FROM information_schema.triggers
+          """,
+          []
+        )
+
+      values = Enum.map(rows, &List.first/1)
+
+      assert "ew_some_weird_trigger" not in values
+      assert "non_ecto_watch_trigger" in values
+
+      %Postgrex.Result{rows: rows} =
+        Ecto.Adapters.SQL.query!(
+          TestRepo,
+          """
+          SELECT p.proname AS name
+          FROM pg_proc p LEFT JOIN pg_namespace n ON p.pronamespace = n.oid
+          WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+          """,
+          []
+        )
+
+      values = Enum.map(rows, &List.first/1)
+
+      assert "ew_some_weird_func" not in values
+      assert "non_ecto_watch_func" in values
+    end
+  end
+
+  describe "inserts" do
+    test "get notification about inserts" do
+      start_supervised!(
+        {EctoWatch,
+         repo: TestRepo,
+         pub_sub: TestPubSub,
+         watchers: [
+           {SuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLong, :inserted}
+         ]}
+      )
+
+      EctoWatch.subscribe(
+        {SuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLong, :inserted}
+      )
+
+      Ecto.Adapters.SQL.query!(
+        TestRepo,
+        "INSERT INTO super_long (the_string, inserted_at, updated_at) VALUES ('new value', NOW(), NOW())",
+        []
+      )
+
+      assert_receive {{SuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLong,
+                       :inserted}, %{id: 2}}
+
+      EctoWatch.unsubscribe(
+        {SuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLong, :inserted}
+      )
+
+      Ecto.Adapters.SQL.query!(
+        TestRepo,
+        "INSERT INTO super_long (the_string, inserted_at, updated_at) VALUES ('the value',  NOW(), NOW())",
+        []
+      )
+
+      refute_receive {{SuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLongSuperLong,
+                       :inserted}, _}
+    end
+  end
+end

--- a/test/ecto_watch_test.exs
+++ b/test/ecto_watch_test.exs
@@ -1532,9 +1532,9 @@ defmodule EctoWatchTest do
                label: EctoWatchTest.Thing
              }
 
-      assert details.function_name == "ew_deleted_for_ectowatchtest_thing_func"
-      assert details.trigger_name == "ew_deleted_for_ectowatchtest_thing_trigger"
-      assert details.notify_channel == "ew_deleted_for_ectowatchtest_thing"
+      assert details.function_name == "ew_d_for_ectowatchtest_thing_func"
+      assert details.trigger_name == "ew_d_for_ectowatchtest_thing_trig"
+      assert details.notify_channel == "ew_d_for_ectowatchtest_thing"
 
       details = EctoWatch.details(:thing_custom_event)
 
@@ -1559,7 +1559,7 @@ defmodule EctoWatchTest do
              }
 
       assert details.function_name == "ew_for_thing_custom_event_func"
-      assert details.trigger_name == "ew_for_thing_custom_event_trigger"
+      assert details.trigger_name == "ew_for_thing_custom_event_trig"
       assert details.notify_channel == "ew_for_thing_custom_event"
     end
   end

--- a/test/ecto_watch_test.exs
+++ b/test/ecto_watch_test.exs
@@ -5,8 +5,6 @@ defmodule EctoWatchTest do
 
   import ExUnit.CaptureLog
 
-  # TODO: Long module names (testing for limits of postgres labels)
-  # TODO: More tests for label option
   # TODO: Pass non-lists to `extra_columns`
   # TODO: Pass strings in list to `extra_columns`
 

--- a/test/label_test.exs
+++ b/test/label_test.exs
@@ -1,0 +1,52 @@
+defmodule EctoWatch.LabelTest do
+  use ExUnit.Case
+  alias EctoWatch.Label
+
+  defmodule Thing do
+    use Ecto.Schema
+
+    schema "things" do
+      field(:the_string, :string)
+    end
+  end
+
+  test "atom + update_type" do
+    assert Label.unique_label({MyApp.One, :updated}) == :"ew_u_for_Elixir.MyApp.One"
+    assert Label.unique_label({MyApp.One, :deleted}) == :"ew_d_for_Elixir.MyApp.One"
+    assert Label.unique_label({MyApp.One, :inserted}) == :"ew_i_for_Elixir.MyApp.One"
+
+    assert Label.unique_label({:some_topic, :updated}) == :ew_u_for_some_topic
+    assert Label.unique_label({:some_topic, :deleted}) == :ew_d_for_some_topic
+    assert Label.unique_label({:some_topic, :inserted}) == :ew_i_for_some_topic
+  end
+
+  test "ecto schema + update_type" do
+    assert Label.unique_label({Thing, :updated}) == :ew_u_for_ectowatch_labeltest_thing
+    assert Label.unique_label({Thing, :deleted}) == :ew_d_for_ectowatch_labeltest_thing
+    assert Label.unique_label({Thing, :inserted}) == :ew_i_for_ectowatch_labeltest_thing
+  end
+
+  test "long atom + update_type" do
+    assert Label.unique_label(
+             {:super_long_super_long_super_long_super_long_super_long_super_long, :updated}
+           ) == :ew_u_for_super_long_super_long_super_long_super_l_62135037
+
+    assert Label.unique_label(
+             {:super_long_super_long_super_long_super_long_super_long_super_long, :deleted}
+           ) == :ew_d_for_super_long_super_long_super_long_super_l_62135037
+
+    assert Label.unique_label(
+             {:super_long_super_long_super_long_super_long_super_long_super_long, :inserted}
+           ) == :ew_i_for_super_long_super_long_super_long_super_l_62135037
+  end
+
+  test "long atom with same prefix do not collide!" do
+    assert Label.unique_label(
+             {:super_long_super_long_super_long_super_long_super_long_super_long1, :updated}
+           ) == :ew_u_for_super_long_super_long_super_long_super__117515674
+
+    assert Label.unique_label(
+             {:super_long_super_long_super_long_super_long_super_long_super_long2, :updated}
+           ) == :ew_u_for_super_long_super_long_super_long_super_l_76543505
+  end
+end


### PR DESCRIPTION
Hey @cheerfulstoic ,

Thanks for EctoWatch! I hit the max trigger length bug in my app, it did cost me quite some hours to understand the reasons behind it. 

My solution was to provide a checksum for very long labels, it seems to be working OK.
The PR is not backwards-compatible, so a proper version bump would be required. 

I have looked at the other open PR, and I think this approach is more robust. 

Cheers and I hope this helps.
Roman

