### PR TITLE
Supports "source" columns and camelCasing of columns

### DIFF
--- a/guides/introduction/Watching without a schema.md
+++ b/guides/introduction/Watching without a schema.md
@@ -10,6 +10,7 @@ Since ecto supports working with tables withoun needed a schema, you may also wa
       %{
         table_name: "comments",
         primary_key: :ID,
+        column_map: %{body: :bodyContent},
         columns: [:title, :body, :author_id, :post_id],
         association_columns: [:author_id, :post_id]
       }, :updated, extra_columns: [:post_id]
@@ -24,6 +25,7 @@ Supported keys for configuring a table without a schema:
  * `schema_prefix` (optional, defaults to `public`)
  * `table_name` (required)
  * `primary_key` (optional, defaults to `id`)
+ * `column_map` (optional, defaults to `%{}`)
  * `columns` (optional, defaults to `[]`)
  * `association_columns` (optional, defaults to `[]`)
 

--- a/lib/ecto_watch/options/watcher_options.ex
+++ b/lib/ecto_watch/options/watcher_options.ex
@@ -33,11 +33,7 @@ defmodule EctoWatch.Options.WatcherOptions do
       [primary_key] = schema_mod.__schema__(:primary_key)
 
       fields = schema_mod.__schema__(:fields)
-
-      field_map =
-        Enum.reduce(fields, %{}, fn field, acc ->
-          Map.put(acc, field, schema_mod.__schema__(:field_source, field))
-        end)
+      column_map = Map.new(fields, &{&1, schema_mod.__schema__(:field_source, &1)})
 
       association_columns =
         schema_mod.__schema__(:associations)
@@ -48,7 +44,7 @@ defmodule EctoWatch.Options.WatcherOptions do
         schema_prefix: schema_prefix,
         table_name: table_name,
         primary_key: primary_key,
-        column_map: field_map,
+        column_map: column_map,
         columns: fields,
         association_columns: association_columns,
         label: schema_mod

--- a/lib/ecto_watch/options/watcher_options.ex
+++ b/lib/ecto_watch/options/watcher_options.ex
@@ -16,6 +16,7 @@ defmodule EctoWatch.Options.WatcherOptions do
       :schema_prefix,
       :table_name,
       :primary_key,
+      :column_map,
       :columns,
       :association_columns,
       :label
@@ -33,6 +34,11 @@ defmodule EctoWatch.Options.WatcherOptions do
 
       fields = schema_mod.__schema__(:fields)
 
+      field_map =
+        Enum.reduce(fields, %{}, fn field, acc ->
+          Map.put(acc, field, schema_mod.__schema__(:field_source, field))
+        end)
+
       association_columns =
         schema_mod.__schema__(:associations)
         |> Enum.map(&schema_mod.__schema__(:association, &1))
@@ -42,6 +48,7 @@ defmodule EctoWatch.Options.WatcherOptions do
         schema_prefix: schema_prefix,
         table_name: table_name,
         primary_key: primary_key,
+        column_map: field_map,
         columns: fields,
         association_columns: association_columns,
         label: schema_mod
@@ -59,6 +66,7 @@ defmodule EctoWatch.Options.WatcherOptions do
         schema_prefix: to_string(schema_prefix),
         table_name: to_string(opts.table_name),
         primary_key: opts.primary_key,
+        column_map: opts[:column_map] || %{},
         columns: opts.columns,
         association_columns: opts[:association_columns] || [],
         label: "#{schema_prefix}|#{opts.table_name}"
@@ -116,6 +124,11 @@ defmodule EctoWatch.Options.WatcherOptions do
         type: {:list, :atom},
         required: false,
         default: []
+      ],
+      column_map: [
+        type: {:map, :atom, :atom},
+        required: false,
+        default: %{}
       ]
     ]
 

--- a/lib/ecto_watch/watcher_server.ex
+++ b/lib/ecto_watch/watcher_server.ex
@@ -56,7 +56,12 @@ defmodule EctoWatch.WatcherServer do
 
         :updated ->
           if options.trigger_columns && options.trigger_columns != [] do
-            "UPDATE OF #{Enum.join(options.trigger_columns, ", ")}"
+            # Get the actual column names from the schema definition and make
+            # sure they are quoted in case of special characters
+            options.trigger_columns
+            |> Enum.map(&"\"#{options.schema_definition.label.__schema__(:field_source, &1)}\"")
+            |> Enum.join(", ")
+            |> then(&"UPDATE OF #{&1}")
           else
             "UPDATE"
           end

--- a/lib/test_repo.ex
+++ b/lib/test_repo.ex
@@ -9,10 +9,11 @@ defmodule EctoWatch.TestRepo do
     {:ok,
      Keyword.merge(
        config,
-       username: "postgres",
-       password: "postgres",
-       hostname: "localhost",
-       database: "ecto_watch",
+       username: System.get_env("PGUSER", "postgres"),
+       password: System.get_env("PGPASSWORD", "postgres"),
+       hostname: System.get_env("PGHOST", "localhost"),
+       database: System.get_env("PGDATABASE", "ecto_watch"),
+       port: System.get_env("PGPORT", "5432"),
        stacktrace: true,
        show_sensitive_data_on_connection_error: true,
        pool_size: 10


### PR DESCRIPTION
This allows you to specify columns on update that have a `source:` defined in the schema. It also adds quoting of columns in case the columns are using `camelCasing`.