### PR TITLE
feat: An option to disable triggers validation

### DIFF
--- a/lib/ecto_watch.ex
+++ b/lib/ecto_watch.ex
@@ -35,7 +35,7 @@ defmodule EctoWatch do
     children = [
       {Postgrex.Notifications, postgrex_notifications_options},
       {EctoWatch.WatcherSupervisor, options},
-      {WatcherTriggerValidator, nil}
+      {WatcherTriggerValidator, options}
     ]
 
     Supervisor.init(children, strategy: :rest_for_one)

--- a/lib/ecto_watch/options.ex
+++ b/lib/ecto_watch/options.ex
@@ -3,12 +3,13 @@ defmodule EctoWatch.Options do
 
   alias EctoWatch.Options.WatcherOptions
 
-  defstruct [:repo_mod, :pub_sub_mod, :watchers, :debug?]
+  defstruct [:repo_mod, :pub_sub_mod, :watchers, :debug?, :validate_triggers?]
 
   def new(opts) do
     %__MODULE__{
       repo_mod: opts[:repo],
       pub_sub_mod: opts[:pub_sub],
+      validate_triggers?: opts[:validate_triggers?],
       watchers:
         Enum.map(opts[:watchers], fn watcher_opts ->
           WatcherOptions.new(watcher_opts, opts[:debug?])
@@ -34,6 +35,11 @@ defmodule EctoWatch.Options do
         type: :boolean,
         required: false,
         default: false
+      ],
+      validate_triggers?: [
+        type: :boolean,
+        required: false,
+        default: true
       ]
     ]
 

--- a/lib/ecto_watch/watcher_trigger_validator.ex
+++ b/lib/ecto_watch/watcher_trigger_validator.ex
@@ -12,8 +12,12 @@ defmodule EctoWatch.WatcherTriggerValidator do
 
   require Logger
 
-  def start_link(_) do
-    Task.start_link(__MODULE__, :run, [nil])
+  def start_link(%EctoWatch.Options{} = options) do
+    if options.validate_triggers? do
+      Task.start_link(__MODULE__, :run, [nil])
+    else
+      :ignore
+    end
   end
 
   defmodule TriggerDetails do


### PR DESCRIPTION
The changes introduce an option that disables triggers validation

The motivation behind the option is aimed mainly at test environments. Validation is great, but it works in an asynchronous manner, which gets in the way of sandboxed repos (`Ecto.Adapters.SQL.Sandbox.mode(Repo, :manual)`)

So, when running tests, you can hit the following error:

<details>

<summary>
(DBConnection.OwnershipError) cannot find ownership process for #PID
</summary>

```
2025-06-14 16:16:31.087 [error] Task #PID<0.629.0> started from EctoWatch terminating
** (DBConnection.OwnershipError) cannot find ownership process for #PID<0.629.0>.

When using ownership, you must manage connections in one
of the four ways:

* By explicitly checking out a connection
* By explicitly allowing a spawned process
* By running the pool in shared mode
* By using :caller option with allowed process

The first two options require every new process to explicitly
check a connection out or be allowed by calling checkout or
allow respectively.

The third option requires a {:shared, pid} mode to be set.
If using shared mode in tests, make sure your tests are not
async.

The fourth option requires [caller: pid] to be used when
checking out a connection from the pool. The caller process
should already be allowed on a connection.

If you are reading this error, it means you have not done one
of the steps above or that the owner process has crashed.

See Ecto.Adapters.SQL.Sandbox docs for more information.
    (ecto_sql 3.12.1) lib/ecto/adapters/sql.ex:1093: Ecto.Adapters.SQL.raise_sql_call_error/1
    (ecto_watch 0.13.2) lib/ecto_watch/watcher_trigger_validator.ex:180: EctoWatch.WatcherTriggerValidator.sql_query/2
    (ecto_watch 0.13.2) lib/ecto_watch/watcher_trigger_validator.ex:147: EctoWatch.WatcherTriggerValidator.find_triggers/1
    (ecto_watch 0.13.2) lib/ecto_watch/watcher_trigger_validator.ex:114: anonymous fn/1 in EctoWatch.WatcherTriggerValidator.triggers_by_repo_mod/0
    (elixir 1.18.4) lib/map.ex:257: Map.do_map/2
    (elixir 1.18.4) lib/map.ex:251: Map.new_from_map/2
    (ecto_watch 0.13.2) lib/ecto_watch/watcher_trigger_validator.ex:38: EctoWatch.WatcherTriggerValidator.run/1
    (elixir 1.18.4) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
Function: &EctoWatch.WatcherTriggerValidator.run/1
    Args: [nil]

```
</details>

From my understanding, that happens because the validator tries to return a database connection to the pool, but isn't authorized to do that. Mostly because it was spawned outside test cases.

The `validate_triggers?` makes it possible to skip validation in tests and avoid the above error altogether.

---

That said, please let me know if you have any other ideas to avoid the mentioned scenario. I'm more than willing to cooperate on this.

Also, thank you for such a nice library! 🙇 