### PR TITLE
chore: Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Often in Elixir applications a `Phoenix.PubSub.broadcast` is inserted into the a
  * Often full records are used which can scale poorly since messages in Elixir are copied in memory when sent.
  * Sometimes records are sent preloaded with different associations in different cases, requiring either careful coordination or sending all associations regardless of where they are needed.
 
-By getting updates directly from PostgreSQL, EctoWatch ensures that messages are sent for *every* change (even changes from other clients of the database).  EctoWatch also establishes a simple, standardized set of messages for inserts, updates, and deletes so that there can be consistency across your application.  By default only the id of the record is sent (makeing for smaller messages).
+By getting updates directly from PostgreSQL, EctoWatch ensures that messages are sent for *every* change (even changes from other clients of the database).  EctoWatch also establishes a simple, standardized set of messages for inserts, updates, and deletes so that there can be consistency across your application.  By default only the id of the record is sent (making for smaller messages).
 
 ## Example use-cases for `EctoWatch`
 
@@ -121,5 +121,5 @@ be found at <https://hexdocs.pm/ecto_watch>.
 [^1]: more info about PubSub message standards:
   - Having a single topic (e.g. `users`) means that all messages are sent to all subscribers, which can be inefficient.
   - Having a topic per record (e.g. `users:1`, `users:2`, etc.) means that a subscriber needs to subscribe to every record, which can be inefficient.
-  - There may be inconsistancy in pluralization of topics (e.g. a `user` vs. `packages` topics) which can be confusing and lead to bugs.
+  - There may be inconsistency in pluralization of topics (e.g. a `user` vs. `packages` topics) which can be confusing and lead to bugs.
   - Having a message that is just `{:updated, id}` doesn't make it clear which schema was updated, using `{schema, id}` doesn't make it clear which operation happened.

--- a/guides/howtos/Upgrading Versions.md
+++ b/guides/howtos/Upgrading Versions.md
@@ -37,7 +37,7 @@ def handle_info({:inserted, Comment, %{id: id}}, socket) do
   # ...
 ```
 
-With versios 0.8.0 the update type is implied by the label, so you can subscribe simply by doing:
+With version 0.8.0 the update type is implied by the label, so you can subscribe simply by doing:
 
 ```elixir
 # subscribe:
@@ -64,9 +64,7 @@ def handle_info({{Comment, :inserted}, %{id: id}}, socket) do
 
 You can think of the first argument of `subscribe` or the first element of the tuple as an lookup identifier for the watcher which is either `{ecto_schema(), update_type()}` or a label atom.  So handling a label would just be:
 
-
 ```elixir
 def handle_info({:title_or_body_updated, %{id: id}}, socket) do
   # ...
 ```
-

--- a/guides/other/Potental TODOs.md
+++ b/guides/other/Potental TODOs.md
@@ -1,8 +1,0 @@
- * Support features of `CREATE TRIGGER`:
-   * allow specifying a condition for when the trigger should fire
- * Allow watchers to support adapter pattern.  Potential adapters:
-   * Phoenix PubSub (the default, would work like it does now)
-   * GenStage producer
-   * Creating a batch-processing GenServer to reduce queries to the database.
- * Allow for local broadcasting of Phoenix.PubSub messages
-

--- a/guides/other/Potential TODOs.md
+++ b/guides/other/Potential TODOs.md
@@ -1,0 +1,7 @@
+* Support features of `CREATE TRIGGER`:
+  * allow specifying a condition for when the trigger should fire
+* Allow watchers to support adapter pattern.  Potential adapters:
+  * Phoenix PubSub (the default, would work like it does now)
+  * GenStage producer
+  * Creating a batch-processing GenServer to reduce queries to the database.
+* Allow for local broadcasting of Phoenix.PubSub messages

--- a/lib/ecto_watch/watcher_server.ex
+++ b/lib/ecto_watch/watcher_server.ex
@@ -1,6 +1,6 @@
 defmodule EctoWatch.WatcherServer do
   @moduledoc """
-  Internal GenServer for the individiual change watchers which are configured by end users
+  Internal GenServer for the individual change watchers which are configured by end users
 
   Used internally, but you'll see it in your application supervision tree.
   """

--- a/lib/ecto_watch/watcher_trigger_validator.ex
+++ b/lib/ecto_watch/watcher_trigger_validator.ex
@@ -1,6 +1,6 @@
 defmodule EctoWatch.WatcherTriggerValidator do
   @moduledoc """
-  Intenal task run as part of the EctoWatch supervision tree to check for a match between the triggers
+  Internal task run as part of the EctoWatch supervision tree to check for a match between the triggers
   that are in the database and the triggers that were started via the configuration.
 
   Used internally, but you'll see it in your application supervision tree.

--- a/mix.exs
+++ b/mix.exs
@@ -78,7 +78,7 @@ defmodule EctoWatch.MixProject do
       "guides/introduction/Testing.md",
       "guides/introduction/Notes.md",
       "guides/howtos/Upgrading Versions.md",
-      "guides/other/Potental TODOs.md",
+      "guides/other/Potential TODOs.md",
       "CHANGELOG.md"
     ]
   end


### PR DESCRIPTION
The changes fix typos using, well, [crate-ci/typos: Source code spell checker](https://github.com/crate-ci/typos)