### PR TITLE
fix: Populate the `debug?` options field

### DIFF
--- a/lib/ecto_watch/options.ex
+++ b/lib/ecto_watch/options.ex
@@ -9,6 +9,7 @@ defmodule EctoWatch.Options do
     %__MODULE__{
       repo_mod: opts[:repo],
       pub_sub_mod: opts[:pub_sub],
+      debug?: opts[:debug?],
       watchers:
         Enum.map(opts[:watchers], fn watcher_opts ->
           WatcherOptions.new(watcher_opts, opts[:debug?])


### PR DESCRIPTION
The changes populate the `EctoWatch.Options.debug?` field

The struct's field is yet to be used directly, as far as I can tell from the code. But unless it's intentional, it would be helpful to have a specified value in the field. As for now, it has the `nil` value regardless of the passes arguments.

Though, watchers' optional are populated with the specified value, and that what matters currently.